### PR TITLE
update guide to allow leading underscores for privates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2410,7 +2410,7 @@ Other Style Guides
   <a name="naming--leading-underscore"></a><a name="22.4"></a>
   - [22.4](#naming--leading-underscore) Use a single leading underscore to indicate a private method/variable. Do not use trailing or double-leading underscores. eslint: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html) jscs: [`disallowDanglingUnderscores`](http://jscs.info/rule/disallowDanglingUnderscores)
 
-    > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Using a leading underscore is a common convention to mean “private”. Because we're not publishing a public JS API, it's a useful convention. Warning: This convention might lead developers to wrongly think that a change won't count as breaking, or that tests aren't needed.
+    > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Using a leading underscore is a common convention to mean “private”. Because we're not publishing a public JS API, it's a useful convention.
 
     ```javascript
     // bad

--- a/README.md
+++ b/README.md
@@ -2408,18 +2408,18 @@ Other Style Guides
     ```
 
   <a name="naming--leading-underscore"></a><a name="22.4"></a>
-  - [22.4](#naming--leading-underscore) Do not use trailing or leading underscores. eslint: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html) jscs: [`disallowDanglingUnderscores`](http://jscs.info/rule/disallowDanglingUnderscores)
+  - [22.4](#naming--leading-underscore) Use a single leading underscore to indicate a private method/variable. Do not use trailing or double-leading underscores. eslint: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html) jscs: [`disallowDanglingUnderscores`](http://jscs.info/rule/disallowDanglingUnderscores)
 
-    > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won't count as breaking, or that tests aren't needed. tl;dr: if you want something to be “private”, it must not be observably present.
+    > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Using a leading underscore is a common convention to mean “private”. Because we're not publishing a public JS API, it's a useful convention. Warning: This convention might lead developers to wrongly think that a change won't count as breaking, or that tests aren't needed.
 
     ```javascript
     // bad
     this.__firstName__ = 'Panda';
     this.firstName_ = 'Panda';
-    this._firstName = 'Panda';
 
     // good
-    this.firstName = 'Panda';
+    this.firstName = 'Panda'; // normal variable
+    this._firstName = 'Panda'; // indicate private
     ```
 
   <a name="naming--self-this"></a><a name="22.5"></a>


### PR DESCRIPTION
Allow leading underscores for private method/variable names, as per style guide meeting.